### PR TITLE
Update composer dev notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ Deliver a holistic, faith-driven digital backbone for LCCD, empowering every use
    The migrations add and then remove a column on the `audit_trails` table. Run
    them in chronological order or see [Migration Sequence](docs/migration-sequence.md) for details.
 8. Ensure `public/storage` is linked. The `composer dev` script checks and runs `php artisan storage:link` if needed.
-9. Start the local server using `php artisan serve` or `composer dev` for hot reloading.
-10. Run a queue worker with `php artisan queue:work` so queued notifications are processed.
-11. Execute the test suite with `php artisan test` to verify the setup.
+9. **Note:** `composer dev` uses [Pail](https://github.com/laravel/pail) under the hood and therefore requires the PHP `pcntl` extension. Windows users can manually run `php artisan serve`, `php artisan queue:listen`, and `npm run dev` or use WSL where `pcntl` is available.
+10. Start the local server using `php artisan serve` or `composer dev` for hot reloading.
+11. Run a queue worker with `php artisan queue:work` so queued notifications are processed.
+12. Execute the test suite with `php artisan test` to verify the setup.
 
 ---
 

--- a/docs/codebase_overview.md
+++ b/docs/codebase_overview.md
@@ -53,6 +53,10 @@ Each module has its own documentation within the `docs/` directory.
    ```bash
    composer dev
    ```
+   `composer dev` relies on [Pail](https://github.com/laravel/pail) which
+   requires the PHP `pcntl` extension. Windows users can run the underlying
+   `php artisan serve`, `php artisan queue:listen`, and `npm run dev` commands
+   manually or use WSL where `pcntl` is available.
 5. Execute the automated test suite:
    ```bash
    php artisan test


### PR DESCRIPTION
## Summary
- add notice about `pcntl` requirement for `composer dev`
- clarify `pcntl` needs in codebase overview docs

## Testing
- `php artisan test` *(fails: Failed opening required '...HTMLPurifier.composer.php')*

------
https://chatgpt.com/codex/tasks/task_b_6861f1fe1000832497d5cc31ab3af94c